### PR TITLE
ubuntu compilation fix

### DIFF
--- a/config/ubuntu.cmake
+++ b/config/ubuntu.cmake
@@ -7,7 +7,7 @@ else()
   set(ENV{CXX} g++) # C++ compiler for serial build
 endif()
 
-set(USER_CXX_FLAGS "-std=c++11")
+set(USER_CXX_FLAGS "-std=c++14")
 set(USER_CXX_FLAGS_RELEASE "-Ofast -DNDEBUG -mtune=native -march=native")
 set(USER_CXX_FLAGS_DEBUG "-O0 -g -Wall -Wno-unknown-pragmas")
 


### PR DESCRIPTION
Some std functions are used which are only available in the standard library of C++14, so change the GCC std flag to use version 14 instead of 11. Also gets rid of many warnings during compilation. 