### PR TITLE
loop through k with correct limits

### DIFF
--- a/src/thermo_moist.cxx
+++ b/src/thermo_moist.cxx
@@ -762,7 +762,7 @@ void Thermo_moist<TF>::get_thermo_field(Field3d<TF>& fld, std::string name, bool
     else if (name == "T")
     {
         calc_T(fld.fld.data(), fields.sp.at("thl")->fld.data(), fields.sp.at("qt")->fld.data(), base.pref.data(), base.exnref.data(),
-               gd.istart, gd.iend, gd.jstart, gd.jend, gd.kstart, gd.kend, gd.icells, gd.ijcells, gd.kcells);
+               gd.istart, gd.iend, gd.jstart, gd.jend, gd.kstart, gd.kend, gd.icells, gd.ijcells);
     }
     else if (name == "T_h")
     {
@@ -1006,6 +1006,7 @@ void Thermo_moist<TF>::exec_stats(Stats<TF>& stats)
     get_thermo_field(*ql, "ql", true, true);
     stats.calc_stats("ql", *ql, no_offset, no_threshold, {"mean","cover","frac","path"});
 
+
     fields.release_tmp(ql);
 
     if (bs_stats.swupdatebasestate)
@@ -1015,6 +1016,7 @@ void Thermo_moist<TF>::exec_stats(Stats<TF>& stats)
         stats.set_prof("rho"    , bs_stats.rhoref);
         stats.set_prof("rhoh"   , bs_stats.rhorefh);
     }
+
 }
 
 

--- a/src/thermo_moist.cxx
+++ b/src/thermo_moist.cxx
@@ -303,18 +303,20 @@ namespace
                const TF* const restrict pref, const TF* const restrict exnref,
                const int istart, const int iend,
                const int jstart, const int jend,
-               const int jj, const int kk, const int kcells)
+               const int kstart, const int kend,
+               const int jj, const int kk)
    {
        #pragma omp parallel for
-       for (int k=0; k<kcells; ++k)
+       for (int k=kstart; k<kend; ++k)
+       {
            for (int j=jstart; j<jend; ++j)
                #pragma ivdep
                for (int i=istart; i<iend; ++i)
                {
                    const int ijk = i + j*jj+ k*kk;
-
                    T[ijk] = sat_adjust(thl[ijk], qt[ijk], pref[k], exnref[k]).t;
                }
+       }
    }
 
    template<typename TF>
@@ -760,7 +762,7 @@ void Thermo_moist<TF>::get_thermo_field(Field3d<TF>& fld, std::string name, bool
     else if (name == "T")
     {
         calc_T(fld.fld.data(), fields.sp.at("thl")->fld.data(), fields.sp.at("qt")->fld.data(), base.pref.data(), base.exnref.data(),
-               gd.istart, gd.iend, gd.jstart, gd.jend, gd.icells, gd.ijcells, gd.kcells);
+               gd.istart, gd.iend, gd.jstart, gd.jend, gd.kstart, gd.kend, gd.icells, gd.ijcells, gd.kcells);
     }
     else if (name == "T_h")
     {


### PR DESCRIPTION
This fixes a bug in `calc_T` caused by exnref which had values of 0 at k=0 and k=cells