### PR TITLE
Flexi field3d io

### DIFF
--- a/include/field3d_io.h
+++ b/include/field3d_io.h
@@ -35,8 +35,8 @@ class Field3d_io
         Field3d_io(Master&, Grid<TF>&);
         ~Field3d_io();
 
-        int save_field3d(TF*, TF*, TF*, const char*, const TF); // Saves a full 3d field.
-        int load_field3d(TF*, TF*, TF*, const char*, const TF); // Loads a full 3d field.
+        int save_field3d(TF*, TF*, TF*, const char*, const TF, int, int); // Saves a full 3d field.
+        int load_field3d(TF*, TF*, TF*, const char*, const TF, int, int); // Loads a full 3d field.
 
         int save_xz_slice(TF*, TF*, const char*, int);           // Saves a xz-slice from a 3d field.
         int save_yz_slice(TF*, TF*, const char*, int);           // Saves a yz-slice from a 3d field.
@@ -46,7 +46,5 @@ class Field3d_io
     private:
         Master& master;
         Grid<TF>& grid;
-
-        bool sw_transpose;  // tmp
 };
 #endif

--- a/include/field3d_io.h
+++ b/include/field3d_io.h
@@ -40,7 +40,7 @@ class Field3d_io
 
         int save_xz_slice(TF*, TF*, const char*, int);           // Saves a xz-slice from a 3d field.
         int save_yz_slice(TF*, TF*, const char*, int);           // Saves a yz-slice from a 3d field.
-        int save_xy_slice(TF*, TF*, const char*, int kslice=-1); // Saves a xy-slice from a 3d field.
+        int save_xy_slice(TF*, TF*, const char*, int kslice=0);  // Saves a xy-slice from a 3d field.
         int load_xy_slice(TF*, TF*, const char*, int kslice=-1); // Loads a xy-slice.
 
     private:

--- a/include/field3d_io.h
+++ b/include/field3d_io.h
@@ -38,8 +38,8 @@ class Field3d_io
         int save_field3d(TF*, TF*, TF*, const char*, const TF, int, int); // Saves a full 3d field.
         int load_field3d(TF*, TF*, TF*, const char*, const TF, int, int); // Loads a full 3d field.
 
-        int save_xz_slice(TF*, TF*, const char*, int);           // Saves a xz-slice from a 3d field.
-        int save_yz_slice(TF*, TF*, const char*, int);           // Saves a yz-slice from a 3d field.
+        int save_xz_slice(TF*, TF*, const char*, int, int, int); // Saves a xz-slice from a 3d field.
+        int save_yz_slice(TF*, TF*, const char*, int, int, int); // Saves a yz-slice from a 3d field.
         int save_xy_slice(TF*, TF*, const char*, int kslice=0);  // Saves a xy-slice from a 3d field.
         int load_xy_slice(TF*, TF*, const char*, int kslice=-1); // Loads a xy-slice.
 

--- a/include/field3d_io.h
+++ b/include/field3d_io.h
@@ -46,7 +46,6 @@ class Field3d_io
     private:
         Master& master;
         Grid<TF>& grid;
-        Transpose<TF> transpose;
 
         bool sw_transpose;  // tmp
 };

--- a/include/field3d_io.h
+++ b/include/field3d_io.h
@@ -35,8 +35,6 @@ class Field3d_io
         Field3d_io(Master&, Grid<TF>&);
         ~Field3d_io();
 
-        void init();
-
         int save_field3d(TF*, TF*, TF*, const char*, const TF); // Saves a full 3d field.
         int load_field3d(TF*, TF*, TF*, const char*, const TF); // Loads a full 3d field.
 
@@ -50,16 +48,6 @@ class Field3d_io
         Grid<TF>& grid;
         Transpose<TF> transpose;
 
-        bool mpitypes;
-
-        void init_mpi();
-        void exit_mpi();
-
-        #ifdef USEMPI
-        MPI_Datatype subarray;   // MPI datatype containing the dimensions of the total array that is contained in one process.
-        MPI_Datatype subxzslice; // MPI datatype containing only one xz-slice.
-        MPI_Datatype subyzslice; // MPI datatype containing only one yz-slice.
-        MPI_Datatype subxyslice; // MPI datatype containing only one xy-slice.
-        #endif
+        bool sw_transpose;  // tmp
 };
 #endif

--- a/src/boundary.cxx
+++ b/src/boundary.cxx
@@ -211,9 +211,6 @@ void Boundary<TF>::init(Input& input, Thermo<TF>& thermo)
 
     // Initialize the boundary cyclic.
     boundary_cyclic.init();
-
-    // Initialize the IO operators.
-    field3d_io.init();
 }
 
 template<typename TF>

--- a/src/cross.cxx
+++ b/src/cross.cxx
@@ -562,7 +562,7 @@ int Cross<TF>::cross_simple(
         for (auto& it: kxyh)
         {
             std::sprintf(filename, "%s.%s.%05d.%07d", name.c_str(), "xy", it, iotime);
-            nerror += check_save(field3d_io.save_xy_slice(data, tmp, filename, it), filename);
+            nerror += check_save(field3d_io.save_xy_slice(data, tmp, filename, it+gd.kgc), filename);
         }
     }
     else
@@ -570,7 +570,7 @@ int Cross<TF>::cross_simple(
         for (auto& it: kxy)
         {
             std::sprintf(filename, "%s.%s.%05d.%07d", name.c_str(), "xy", it, iotime);
-            nerror += check_save(field3d_io.save_xy_slice(data, tmp, filename, it), filename);
+            nerror += check_save(field3d_io.save_xy_slice(data, tmp, filename, it+gd.kgc), filename);
         }
     }
     fields.release_tmp(tmpfld);
@@ -633,7 +633,7 @@ int Cross<TF>::cross_lngrad(TF* restrict a, std::string name, int iotime)
     for (auto& it: kxy)
     {
         std::sprintf(filename, "%s.%s.%05d.%07d", name.c_str(), "xy", it, iotime);
-        nerror += check_save(field3d_io.save_xy_slice(lngrad, tmp, filename, it),filename);
+        nerror += check_save(field3d_io.save_xy_slice(lngrad, tmp, filename, it+gd.kgc),filename);
     }
     fields.release_tmp(tmpfld);
     fields.release_tmp(lngradfld);

--- a/src/cross.cxx
+++ b/src/cross.cxx
@@ -255,7 +255,6 @@ Cross<TF>::Cross(Master& masterin, Grid<TF>& gridin, Fields<TF>& fieldsin, Input
         xz = inputin.get_list<TF>("cross", "xz", "", std::vector<TF>());
         yz = inputin.get_list<TF>("cross", "yz", "", std::vector<TF>());
     }
-
 }
 
 template<typename TF>
@@ -287,8 +286,6 @@ void Cross<TF>::init(double ifactor)
         return;
 
     isampletime = static_cast<unsigned long>(ifactor * sampletime);
-
-    field3d_io.init();
 }
 
 template<typename TF>

--- a/src/cross.cxx
+++ b/src/cross.cxx
@@ -526,7 +526,8 @@ int Cross<TF>::cross_simple(
         for (auto& it: jxzh)
         {
             std::sprintf(filename, "%s.%s.%05d.%07d", name.c_str(), "xz", it, iotime);
-            nerror += check_save(field3d_io.save_xz_slice(data, tmp, filename, it), filename);
+            nerror += check_save(
+                    field3d_io.save_xz_slice(data, tmp, filename, it, gd.kstart, gd.kend), filename);
         }
     }
     else
@@ -534,7 +535,8 @@ int Cross<TF>::cross_simple(
         for (auto& it: jxz)
         {
             std::sprintf(filename, "%s.%s.%05d.%07d", name.c_str(), "xz", it, iotime);
-            nerror += check_save(field3d_io.save_xz_slice(data, tmp, filename, it), filename);
+            nerror += check_save(
+                    field3d_io.save_xz_slice(data, tmp, filename, it, gd.kstart, gd.kend), filename);
         }
     }
 
@@ -544,7 +546,8 @@ int Cross<TF>::cross_simple(
         for (auto& it: ixzh)
         {
             std::sprintf(filename, "%s.%s.%05d.%07d", name.c_str(), "yz", it, iotime);
-            nerror += check_save(field3d_io.save_yz_slice(data, tmp, filename, it), filename);
+            nerror += check_save(
+                    field3d_io.save_yz_slice(data, tmp, filename, it, gd.kstart, gd.kend), filename);
         }
     }
     else
@@ -552,7 +555,8 @@ int Cross<TF>::cross_simple(
         for (auto& it: ixz)
         {
             std::sprintf(filename, "%s.%s.%05d.%07d", name.c_str(), "yz", it, iotime);
-            nerror += check_save(field3d_io.save_yz_slice(data, tmp, filename, it), filename);
+            nerror += check_save(
+                    field3d_io.save_yz_slice(data, tmp, filename, it, gd.kstart, gd.kend), filename);
         }
     }
 
@@ -619,14 +623,16 @@ int Cross<TF>::cross_lngrad(TF* restrict a, std::string name, int iotime)
     for (auto& it: jxz)
     {
         std::sprintf(filename, "%s.%s.%05d.%07d", name.c_str(), "xz", it, iotime);
-        nerror += check_save(field3d_io.save_xz_slice(lngrad, tmp, filename, it),filename);
+        nerror += check_save(
+                field3d_io.save_xz_slice(lngrad, tmp, filename, it, gd.kstart, gd.kend),filename);
     }
 
     // loop over the index arrays to save all yz cross sections
     for (auto& it: ixz)
     {
         std::sprintf(filename, "%s.%s.%05d.%07d", name.c_str(), "yz", it, iotime);
-        nerror += check_save(field3d_io.save_yz_slice(lngrad, tmp, filename, it),filename);
+        nerror += check_save(
+                field3d_io.save_yz_slice(lngrad, tmp, filename, it, gd.kstart, gd.kend),filename);
     }
 
     // loop over the index arrays to save all xy cross sections
@@ -635,6 +641,7 @@ int Cross<TF>::cross_lngrad(TF* restrict a, std::string name, int iotime)
         std::sprintf(filename, "%s.%s.%05d.%07d", name.c_str(), "xy", it, iotime);
         nerror += check_save(field3d_io.save_xy_slice(lngrad, tmp, filename, it+gd.kgc),filename);
     }
+
     fields.release_tmp(tmpfld);
     fields.release_tmp(lngradfld);
 

--- a/src/dump.cxx
+++ b/src/dump.cxx
@@ -113,6 +113,7 @@ std::vector<std::string>* Dump<TF>::get_dumplist()
 template<typename TF>
 void Dump<TF>::save_dump(TF* data, std::string varname, int iotime)
 {
+    auto& gd = grid.get_grid_data();
     const double no_offset = 0.;
     char filename[256];
 
@@ -131,7 +132,11 @@ void Dump<TF>::save_dump(TF* data, std::string varname, int iotime)
         auto tmp1 = tmpfld1.get();
         auto tmp2 = tmpfld1.get();
 
-        if (field3d_io.save_field3d(data, tmp1->fld.data(), tmp2->fld.data(), filename, no_offset))
+        if (field3d_io.save_field3d(
+                    data,
+                    tmp1->fld.data(), tmp2->fld.data(),
+                    filename, no_offset,
+                    gd.kstart, gd.kend))
         {
             master.print_message("FAILED\n");
             throw std::runtime_error("In Dump");

--- a/src/dump.cxx
+++ b/src/dump.cxx
@@ -68,8 +68,6 @@ void Dump<TF>::init(double ifactor)
         return;
 
     isampletime = static_cast<unsigned long>(ifactor * sampletime);
-
-    field3d_io.init();
 }
 
 template<typename TF>

--- a/src/field3d_io.cxx
+++ b/src/field3d_io.cxx
@@ -35,21 +35,12 @@ Field3d_io<TF>::Field3d_io(Master& masterin, Grid<TF>& gridin) :
     master(masterin), grid(gridin),
     transpose(master, grid)
 {
-    mpitypes = false;
+    sw_transpose = true;    // tmp here for now, becomes argument of save_field3d et al.
 }
 
 template<typename TF>
 Field3d_io<TF>::~Field3d_io()
 {
-    exit_mpi();
-}
-
-template<typename TF>
-void Field3d_io<TF>::init()
-{
-    init_mpi();
-
-    transpose.init();
 }
 
 #ifdef USEMPI
@@ -61,65 +52,16 @@ namespace
 }
 
 template<typename TF>
-void Field3d_io<TF>::init_mpi()
+int Field3d_io<TF>::save_field3d(
+        TF* restrict data, TF* restrict tmp1, TF* restrict tmp2,
+        const char* filename, TF offset)
 {
+    // Save the data in transposed order to have large chunks of contiguous disk space.
+    // MPI-IO is not stable on Juqueen and Supermuc otherwise
     auto& gd = grid.get_grid_data();
     auto& md = master.get_MPI_data();
-
-    // The lines below describe the array in case transposes are not used before saving.
-    // int totsize [3] = {kmax, jtot, itot};
-    // int subsize [3] = {kmax, jmax, imax};
-    // int substart[3] = {0, md.mpicoordy*jmax, md.mpicoordx*imax};
-    int totsize [3] = {gd.kmax  , gd.jtot, gd.itot};
-    int subsize [3] = {gd.kblock, gd.jmax, gd.itot};
-    int substart[3] = {md.mpicoordx*gd.kblock, md.mpicoordy*gd.jmax, 0};
-    MPI_Type_create_subarray(3, totsize, subsize, substart, MPI_ORDER_C, mpi_fp_type<TF>(), &subarray);
-    MPI_Type_commit(&subarray);
-
-    // save mpitype for a xz-slice for cross section processing
-    int totxzsize [2] = {gd.kmax, gd.itot};
-    int subxzsize [2] = {gd.kmax, gd.imax};
-    int subxzstart[2] = {0, md.mpicoordx*gd.imax};
-    MPI_Type_create_subarray(2, totxzsize, subxzsize, subxzstart, MPI_ORDER_C, mpi_fp_type<TF>(), &subxzslice);
-    MPI_Type_commit(&subxzslice);
-
-    // save mpitype for a yz-slice for cross section processing
-    int totyzsize [2] = {gd.kmax, gd.jtot};
-    int subyzsize [2] = {gd.kmax, gd.jmax};
-    int subyzstart[2] = {0, md.mpicoordy*gd.jmax};
-    MPI_Type_create_subarray(2, totyzsize, subyzsize, subyzstart, MPI_ORDER_C, mpi_fp_type<TF>(), &subyzslice);
-    MPI_Type_commit(&subyzslice);
-
-    // save mpitype for a xy-slice for cross section processing
-    int totxysize [2] = {gd.jtot, gd.itot};
-    int subxysize [2] = {gd.jmax, gd.imax};
-    int subxystart[2] = {md.mpicoordy*gd.jmax, md.mpicoordx*gd.imax};
-    MPI_Type_create_subarray(2, totxysize, subxysize, subxystart, MPI_ORDER_C, mpi_fp_type<TF>(), &subxyslice);
-    MPI_Type_commit(&subxyslice);
-
-    mpitypes = true;
-}
-
-template<typename TF>
-void Field3d_io<TF>::exit_mpi()
-{
-    if (mpitypes)
-    {
-        MPI_Type_free(&subarray);
-        MPI_Type_free(&subxzslice);
-        MPI_Type_free(&subyzslice);
-        MPI_Type_free(&subxyslice);
-    }
-}
-
-template<typename TF>
-int Field3d_io<TF>::save_field3d(TF* restrict data, TF* restrict tmp1, TF* restrict tmp2, const char* filename, TF offset)
-{
-    auto& gd = grid.get_grid_data();
-    auto& md = master.get_MPI_data();
-
-    // save the data in transposed order to have large chunks of contiguous disk space
-    // MPI-IO is not stable on Juqueen and supermuc otherwise
+    auto tp = Transpose<TF>(master, grid);
+    tp.init();
 
     // extract the data from the 3d field without the ghost cells
     const int jj  = gd.icells;
@@ -128,6 +70,8 @@ int Field3d_io<TF>::save_field3d(TF* restrict data, TF* restrict tmp1, TF* restr
     const int kkb = gd.imax*gd.jmax;
 
     int count = gd.imax*gd.jmax*gd.kmax;
+
+    MPI_Datatype subarray;   // MPI datatype containing the dimensions of the total array that is contained in one process.
 
     for (int k=0; k<gd.kmax; ++k)
         for (int j=0; j<gd.jmax; ++j)
@@ -139,7 +83,27 @@ int Field3d_io<TF>::save_field3d(TF* restrict data, TF* restrict tmp1, TF* restr
                 tmp1[ijkb] = data[ijk] + offset;
             }
 
-    transpose.exec_zx(tmp2, tmp1);
+    if (sw_transpose)
+    {
+        // Transpose the 3D field
+        tp.exec_zx(tmp2, tmp1);
+
+        // Create MPI datatype for writing transposed field
+        int totsize [3] = {gd.kmax,   gd.jtot, gd.itot};
+        int subsize [3] = {gd.kblock, gd.jmax, gd.itot};
+        int substart[3] = {md.mpicoordx*gd.kblock, md.mpicoordy*gd.jmax, 0};
+        MPI_Type_create_subarray(3, totsize, subsize, substart, MPI_ORDER_C, mpi_fp_type<TF>(), &subarray);
+        MPI_Type_commit(&subarray);
+    }
+    else
+    {
+        // Create MPI datatype for writing non-transposed field
+        int totsize [3] = {gd.kmax, gd.jtot, gd.itot};
+        int subsize [3] = {gd.kmax, gd.jmax, gd.imax};
+        int substart[3] = {0, md.mpicoordy*gd.jmax, md.mpicoordx*gd.imax};
+        MPI_Type_create_subarray(3, totsize, subsize, substart, MPI_ORDER_C, mpi_fp_type<TF>(), &subarray);
+        MPI_Type_commit(&subarray);
+    }
 
     MPI_File fh;
     if (MPI_File_open(md.commxy, filename, MPI_MODE_CREATE | MPI_MODE_WRONLY | MPI_MODE_EXCL, MPI_INFO_NULL, &fh))
@@ -152,11 +116,21 @@ int Field3d_io<TF>::save_field3d(TF* restrict data, TF* restrict tmp1, TF* restr
     if (MPI_File_set_view(fh, fileoff, mpi_fp_type<TF>(), subarray, name, MPI_INFO_NULL))
         return 1;
 
-    if (MPI_File_write_all(fh, tmp2, count, mpi_fp_type<TF>(), MPI_STATUS_IGNORE))
-        return 1;
+    if (sw_transpose)
+    {
+        if (MPI_File_write_all(fh, tmp2, count, mpi_fp_type<TF>(), MPI_STATUS_IGNORE))
+            return 1;
+    }
+    else
+    {
+        if (MPI_File_write_all(fh, tmp1, count, mpi_fp_type<TF>(), MPI_STATUS_IGNORE))
+            return 1;
+    }
 
     if (MPI_File_close(&fh))
         return 1;
+
+    MPI_Type_free(&subarray);
 
     return 0;
 }
@@ -164,13 +138,35 @@ int Field3d_io<TF>::save_field3d(TF* restrict data, TF* restrict tmp1, TF* restr
 template<typename TF>
 int Field3d_io<TF>::load_field3d(TF* const restrict data, TF* const restrict tmp1, TF* const restrict tmp2, const char* filename, TF offset)
 {
+    // Read the data (optionally) in transposed order to have large chunks of contiguous disk space.
+    // MPI-IO is not stable on Juqueen and supermuc otherwise.
     auto& gd = grid.get_grid_data();
     auto& md = master.get_MPI_data();
+    auto tp = Transpose<TF>(master, grid);
+    tp.init();
 
-    // Save the data in transposed order to have large chunks of contiguous disk space.
-    // MPI-IO is not stable on Juqueen and supermuc otherwise.
+    MPI_Datatype subarray;   // MPI datatype containing the dimensions of the total array that is contained in one process.
 
-    // read the file
+    if (sw_transpose)
+    {
+        // Create MPI datatype for reading transposed field
+        int totsize [3] = {gd.kmax  , gd.jtot, gd.itot};
+        int subsize [3] = {gd.kblock, gd.jmax, gd.itot};
+        int substart[3] = {md.mpicoordx*gd.kblock, md.mpicoordy*gd.jmax, 0};
+        MPI_Type_create_subarray(3, totsize, subsize, substart, MPI_ORDER_C, mpi_fp_type<TF>(), &subarray);
+        MPI_Type_commit(&subarray);
+    }
+    else
+    {
+        // Create MPI datatype for reading non-transposed field
+        int totsize [3] = {gd.kmax, gd.jtot, gd.itot};
+        int subsize [3] = {gd.kmax, gd.jmax, gd.imax};
+        int substart[3] = {0, md.mpicoordy*gd.jmax, md.mpicoordx*gd.imax};
+        MPI_Type_create_subarray(3, totsize, subsize, substart, MPI_ORDER_C, mpi_fp_type<TF>(), &subarray);
+        MPI_Type_commit(&subarray);
+    }
+
+    // Read the file
     MPI_File fh;
     if (MPI_File_open(md.commxy, filename, MPI_MODE_RDONLY, MPI_INFO_NULL, &fh))
         return 1;
@@ -183,14 +179,23 @@ int Field3d_io<TF>::load_field3d(TF* const restrict data, TF* const restrict tmp
     // extract the data from the 3d field without the ghost cells
     int count = gd.imax*gd.jmax*gd.kmax;
 
-    if (MPI_File_read_all(fh, tmp1, count, mpi_fp_type<TF>(), MPI_STATUS_IGNORE))
-        return 1;
+    if (sw_transpose)
+    {
+        if (MPI_File_read_all(fh, tmp1, count, mpi_fp_type<TF>(), MPI_STATUS_IGNORE))
+            return 1;
+    }
+    else
+    {
+        if (MPI_File_read_all(fh, tmp2, count, mpi_fp_type<TF>(), MPI_STATUS_IGNORE))
+            return 1;
+    }
 
     if (MPI_File_close(&fh))
         return 1;
 
-    // transpose the data back
-    transpose.exec_xz(tmp2, tmp1);
+    // Transpose the 3D field
+    if (sw_transpose)
+        tp.exec_xz(tmp2, tmp1);
 
     const int jj  = gd.icells;
     const int kk  = gd.icells*gd.jcells;
@@ -207,244 +212,236 @@ int Field3d_io<TF>::load_field3d(TF* const restrict data, TF* const restrict tmp
                 data[ijk] = tmp2[ijkb] - offset;
             }
 
+    MPI_Type_free(&subarray);
+
     return 0;
 }
 
 template<typename TF>
 int Field3d_io<TF>::save_xz_slice(TF* restrict data, TF* restrict tmp, const char* filename, int jslice)
 {
-    auto& gd = grid.get_grid_data();
-    auto& md = master.get_MPI_data();
-
-    // extract the data from the 3d field without the ghost cells
-    int nerror = 0;
-
-    const int jj  = gd.icells;
-    const int kk  = gd.icells*gd.jcells;
-    const int kkb = gd.imax;
-
-    int count = gd.imax*gd.kmax;
-
-    for (int k=0; k<gd.kmax; k++)
-#pragma ivdep
-        for (int i=0; i<gd.imax; i++)
-        {
-            // take the modulus of jslice and gd.jmax to have the right offset within proc
-            const int ijk  = i+gd.igc + ((jslice%gd.jmax)+gd.jgc)*jj + (k+gd.kgc)*kk;
-            const int ijkb = i + k*kkb;
-            tmp[ijkb] = data[ijk];
-        }
-
-    if (md.mpicoordy == jslice/gd.jmax)
-    {
-        MPI_File fh;
-        if (MPI_File_open(md.commx, filename, MPI_MODE_CREATE | MPI_MODE_WRONLY | MPI_MODE_EXCL, MPI_INFO_NULL, &fh))
-            ++nerror;
-
-        // select noncontiguous part of 3d array to store the selected data
-        MPI_Offset fileoff = 0; // the offset within the file (header size)
-        char name[] = "native";
-
-        if (!nerror)
-            if (MPI_File_set_view(fh, fileoff, mpi_fp_type<TF>(), subxzslice, name, MPI_INFO_NULL))
-                ++nerror;
-
-        // only write at the procs that contain the slice
-        if (!nerror)
-            if (MPI_File_write_all(fh, tmp, count, mpi_fp_type<TF>(), MPI_STATUS_IGNORE))
-                ++nerror;
-
-        if (!nerror)
-            MPI_File_sync(fh);
-
-        if (!nerror)
-            if (MPI_File_close(&fh))
-                ++nerror;
-    }
-
-    // Gather errors from other processes
-    master.sum(&nerror,1);
-
-    MPI_Barrier(md.commxy);
-
-    return nerror;
+//    auto& gd = grid.get_grid_data();
+//    auto& md = master.get_MPI_data();
+//
+//    // extract the data from the 3d field without the ghost cells
+//    int nerror = 0;
+//
+//    const int jj  = gd.icells;
+//    const int kk  = gd.icells*gd.jcells;
+//    const int kkb = gd.imax;
+//
+//    int count = gd.imax*gd.kmax;
+//
+//    for (int k=0; k<gd.kmax; k++)
+//        #pragma ivdep
+//        for (int i=0; i<gd.imax; i++)
+//        {
+//            // take the modulus of jslice and gd.jmax to have the right offset within proc
+//            const int ijk  = i+gd.igc + ((jslice%gd.jmax)+gd.jgc)*jj + (k+gd.kgc)*kk;
+//            const int ijkb = i + k*kkb;
+//            tmp[ijkb] = data[ijk];
+//        }
+//
+//    if (md.mpicoordy == jslice/gd.jmax)
+//    {
+//        MPI_File fh;
+//        if (MPI_File_open(md.commx, filename, MPI_MODE_CREATE | MPI_MODE_WRONLY | MPI_MODE_EXCL, MPI_INFO_NULL, &fh))
+//            ++nerror;
+//
+//        // select noncontiguous part of 3d array to store the selected data
+//        MPI_Offset fileoff = 0; // the offset within the file (header size)
+//        char name[] = "native";
+//
+//        if (!nerror)
+//            if (MPI_File_set_view(fh, fileoff, mpi_fp_type<TF>(), subxzslice, name, MPI_INFO_NULL))
+//                ++nerror;
+//
+//        // only write at the procs that contain the slice
+//        if (!nerror)
+//            if (MPI_File_write_all(fh, tmp, count, mpi_fp_type<TF>(), MPI_STATUS_IGNORE))
+//                ++nerror;
+//
+//        if (!nerror)
+//            MPI_File_sync(fh);
+//
+//        if (!nerror)
+//            if (MPI_File_close(&fh))
+//                ++nerror;
+//    }
+//
+//    // Gather errors from other processes
+//    master.sum(&nerror,1);
+//
+//    MPI_Barrier(md.commxy);
+//
+//    return nerror;
 }
 
 template<typename TF>
 int Field3d_io<TF>::save_yz_slice(TF* restrict data, TF* restrict tmp, const char* filename, int islice)
 {
-    auto& gd = grid.get_grid_data();
-    auto& md = master.get_MPI_data();
-
-    // extract the data from the 3d field without the ghost cells
-    int nerror = 0;
-
-    const int jj = gd.icells;
-    const int kk = gd.ijcells;
-
-    const int kkb = gd.jmax;
-
-    int count = gd.jmax*gd.kmax;
-
-    // Strip off the ghost cells
-    for (int k=0; k<gd.kmax; k++)
-        #pragma ivdep
-        for (int j=0; j<gd.jmax; j++)
-        {
-            // take the modulus of jslice and jmax to have the right offset within proc
-            const int ijk  = (islice%gd.imax)+gd.igc + (j+gd.jgc)*jj + (k+gd.kgc)*kk;
-            const int ijkb = j + k*kkb;
-            tmp[ijkb] = data[ijk];
-        }
-
-    if (md.mpicoordx == islice/gd.imax)
-    {
-        MPI_File fh;
-        if (MPI_File_open(md.commy, filename, MPI_MODE_CREATE | MPI_MODE_WRONLY | MPI_MODE_EXCL, MPI_INFO_NULL, &fh))
-            ++nerror;
-
-        // select noncontiguous part of 3d array to store the selected data
-        MPI_Offset fileoff = 0; // the offset within the file (header size)
-        char name[] = "native";
-
-        if (!nerror)
-            if (MPI_File_set_view(fh, fileoff, mpi_fp_type<TF>(), subyzslice, name, MPI_INFO_NULL))
-                ++nerror;
-
-        // only write at the procs that contain the slice
-        if (!nerror)
-            if (MPI_File_write_all(fh, tmp, count, mpi_fp_type<TF>(), MPI_STATUS_IGNORE))
-                ++nerror;
-
-        if (!nerror)
-            MPI_File_sync(fh);
-
-        if (!nerror)
-            if (MPI_File_close(&fh))
-                ++nerror;
-    }
-
-    // Gather errors from other processes
-    master.sum(&nerror,1);
-
-    MPI_Barrier(md.commxy);
-
-    return nerror;
+//    auto& gd = grid.get_grid_data();
+//    auto& md = master.get_MPI_data();
+//
+//    // extract the data from the 3d field without the ghost cells
+//    int nerror = 0;
+//
+//    const int jj = gd.icells;
+//    const int kk = gd.ijcells;
+//
+//    const int kkb = gd.jmax;
+//
+//    int count = gd.jmax*gd.kmax;
+//
+//    // Strip off the ghost cells
+//    for (int k=0; k<gd.kmax; k++)
+//        #pragma ivdep
+//        for (int j=0; j<gd.jmax; j++)
+//        {
+//            // take the modulus of jslice and jmax to have the right offset within proc
+//            const int ijk  = (islice%gd.imax)+gd.igc + (j+gd.jgc)*jj + (k+gd.kgc)*kk;
+//            const int ijkb = j + k*kkb;
+//            tmp[ijkb] = data[ijk];
+//        }
+//
+//    if (md.mpicoordx == islice/gd.imax)
+//    {
+//        MPI_File fh;
+//        if (MPI_File_open(md.commy, filename, MPI_MODE_CREATE | MPI_MODE_WRONLY | MPI_MODE_EXCL, MPI_INFO_NULL, &fh))
+//            ++nerror;
+//
+//        // select noncontiguous part of 3d array to store the selected data
+//        MPI_Offset fileoff = 0; // the offset within the file (header size)
+//        char name[] = "native";
+//
+//        if (!nerror)
+//            if (MPI_File_set_view(fh, fileoff, mpi_fp_type<TF>(), subyzslice, name, MPI_INFO_NULL))
+//                ++nerror;
+//
+//        // only write at the procs that contain the slice
+//        if (!nerror)
+//            if (MPI_File_write_all(fh, tmp, count, mpi_fp_type<TF>(), MPI_STATUS_IGNORE))
+//                ++nerror;
+//
+//        if (!nerror)
+//            MPI_File_sync(fh);
+//
+//        if (!nerror)
+//            if (MPI_File_close(&fh))
+//                ++nerror;
+//    }
+//
+//    // Gather errors from other processes
+//    master.sum(&nerror,1);
+//
+//    MPI_Barrier(md.commxy);
+//
+//    return nerror;
 }
 
 template<typename TF>
 int Field3d_io<TF>::save_xy_slice(TF* restrict data, TF* restrict tmp, const char* filename, int kslice)
 {
-    auto& gd = grid.get_grid_data();
-    auto& md = master.get_MPI_data();
-
-    // extract the data from the 3d field without the ghost cells
-    const int jj  = gd.icells;
-    const int kk  = gd.icells*gd.jcells;
-    const int jjb = gd.imax;
-
-    // Subtract the ghost cells in case of a pure 2d plane that does not have ghost cells.
-    if (kslice == -1)
-        kslice = -gd.kgc;
-
-    int count = gd.imax*gd.jmax;
-
-    for (int j=0; j<gd.jmax; j++)
-#pragma ivdep
-        for (int i=0; i<gd.imax; i++)
-        {
-            // take the modulus of jslice and jmax to have the right offset within proc
-            const int ijk  = i+gd.igc + (j+gd.jgc)*jj + (kslice+gd.kgc)*kk;
-            const int ijkb = i + j*jjb;
-            tmp[ijkb] = data[ijk];
-        }
-
-    MPI_File fh;
-    if (MPI_File_open(md.commxy, filename, MPI_MODE_CREATE | MPI_MODE_WRONLY | MPI_MODE_EXCL, MPI_INFO_NULL, &fh))
-        return 1;
-
-    // select noncontiguous part of 3d array to store the selected data
-    MPI_Offset fileoff = 0; // the offset within the file (header size)
-    char name[] = "native";
-
-    if (MPI_File_set_view(fh, fileoff, mpi_fp_type<TF>(), subxyslice, name, MPI_INFO_NULL))
-        return 1;
-
-    // only write at the procs that contain the slice
-    if (MPI_File_write_all(fh, tmp, count, mpi_fp_type<TF>(), MPI_STATUS_IGNORE))
-        return 1;
-
-    MPI_File_sync(fh);
-
-    if (MPI_File_close(&fh))
-        return 1;
-
-    MPI_Barrier(md.commxy);
-
-    return 0;
+//    auto& gd = grid.get_grid_data();
+//    auto& md = master.get_MPI_data();
+//
+//    // extract the data from the 3d field without the ghost cells
+//    const int jj  = gd.icells;
+//    const int kk  = gd.icells*gd.jcells;
+//    const int jjb = gd.imax;
+//
+//    // Subtract the ghost cells in case of a pure 2d plane that does not have ghost cells.
+//    if (kslice == -1)
+//        kslice = -gd.kgc;
+//
+//    int count = gd.imax*gd.jmax;
+//
+//    for (int j=0; j<gd.jmax; j++)
+//        #pragma ivdep
+//        for (int i=0; i<gd.imax; i++)
+//        {
+//            // take the modulus of jslice and jmax to have the right offset within proc
+//            const int ijk  = i+gd.igc + (j+gd.jgc)*jj + (kslice+gd.kgc)*kk;
+//            const int ijkb = i + j*jjb;
+//            tmp[ijkb] = data[ijk];
+//        }
+//
+//    MPI_File fh;
+//    if (MPI_File_open(md.commxy, filename, MPI_MODE_CREATE | MPI_MODE_WRONLY | MPI_MODE_EXCL, MPI_INFO_NULL, &fh))
+//        return 1;
+//
+//    // select noncontiguous part of 3d array to store the selected data
+//    MPI_Offset fileoff = 0; // the offset within the file (header size)
+//    char name[] = "native";
+//
+//    if (MPI_File_set_view(fh, fileoff, mpi_fp_type<TF>(), subxyslice, name, MPI_INFO_NULL))
+//        return 1;
+//
+//    // only write at the procs that contain the slice
+//    if (MPI_File_write_all(fh, tmp, count, mpi_fp_type<TF>(), MPI_STATUS_IGNORE))
+//        return 1;
+//
+//    MPI_File_sync(fh);
+//
+//    if (MPI_File_close(&fh))
+//        return 1;
+//
+//    MPI_Barrier(md.commxy);
+//
+//    return 0;
 }
 
 template<typename TF>
 int Field3d_io<TF>::load_xy_slice(TF* restrict data, TF* restrict tmp, const char* filename, int kslice)
 {
-    auto& gd = grid.get_grid_data();
-    auto& md = master.get_MPI_data();
-
-    // extract the data from the 3d field without the ghost cells
-    const int jj = gd.icells;
-    const int kk = gd.icells*gd.jcells;
-    const int jjb = gd.imax;
-
-    // Subtract the ghost cells in case of a pure 2d plane that does not have ghost cells.
-    if (kslice == -1)
-        kslice = -gd.kgc;
-
-    int count = gd.imax*gd.jmax;
-
-    MPI_File fh;
-    if (MPI_File_open(md.commxy, filename, MPI_MODE_RDONLY, MPI_INFO_NULL, &fh))
-        return 1;
-
-    // select noncontiguous part of 3d array to store the selected data
-    MPI_Offset fileoff = 0; // the offset within the file (header size)
-    char name[] = "native";
-
-    if (MPI_File_set_view(fh, fileoff, mpi_fp_type<TF>(), subxyslice, name, MPI_INFO_NULL))
-        return 1;
-
-    // only write at the procs that contain the slice
-    if (MPI_File_read_all(fh, tmp, count, mpi_fp_type<TF>(), MPI_STATUS_IGNORE))
-        return 1;
-
-    if (MPI_File_close(&fh))
-        return 1;
-
-    MPI_Barrier(md.commxy);
-
-    for (int j=0; j<gd.jmax; j++)
-        #pragma ivdep
-        for (int i=0; i<gd.imax; i++)
-        {
-            // take the modulus of jslice and jmax to have the right offset within proc
-            const int ijk  = i+gd.igc + (j+gd.jgc)*jj + (kslice+gd.kgc)*kk;
-            const int ijkb = i + j*jjb;
-            data[ijk] = tmp[ijkb];
-        }
-
-    return 0;
+//    auto& gd = grid.get_grid_data();
+//    auto& md = master.get_MPI_data();
+//
+//    // extract the data from the 3d field without the ghost cells
+//    const int jj = gd.icells;
+//    const int kk = gd.icells*gd.jcells;
+//    const int jjb = gd.imax;
+//
+//    // Subtract the ghost cells in case of a pure 2d plane that does not have ghost cells.
+//    if (kslice == -1)
+//        kslice = -gd.kgc;
+//
+//    int count = gd.imax*gd.jmax;
+//
+//    MPI_File fh;
+//    if (MPI_File_open(md.commxy, filename, MPI_MODE_RDONLY, MPI_INFO_NULL, &fh))
+//        return 1;
+//
+//    // select noncontiguous part of 3d array to store the selected data
+//    MPI_Offset fileoff = 0; // the offset within the file (header size)
+//    char name[] = "native";
+//
+//    if (MPI_File_set_view(fh, fileoff, mpi_fp_type<TF>(), subxyslice, name, MPI_INFO_NULL))
+//        return 1;
+//
+//    // only write at the procs that contain the slice
+//    if (MPI_File_read_all(fh, tmp, count, mpi_fp_type<TF>(), MPI_STATUS_IGNORE))
+//        return 1;
+//
+//    if (MPI_File_close(&fh))
+//        return 1;
+//
+//    MPI_Barrier(md.commxy);
+//
+//    for (int j=0; j<gd.jmax; j++)
+//        #pragma ivdep
+//        for (int i=0; i<gd.imax; i++)
+//        {
+//            // take the modulus of jslice and jmax to have the right offset within proc
+//            const int ijk  = i+gd.igc + (j+gd.jgc)*jj + (kslice+gd.kgc)*kk;
+//            const int ijkb = i + j*jjb;
+//            data[ijk] = tmp[ijkb];
+//        }
+//
+//    return 0;
 }
 
 #else
-template<typename TF>
-void Field3d_io<TF>::init_mpi()
-{
-}
-
-template<typename TF>
-void Field3d_io<TF>::exit_mpi()
-{
-}
-
 template<typename TF>
 int Field3d_io<TF>::save_field3d(TF* restrict data, TF* restrict tmp1, TF* restrict tmp2,
         const char* filename, const TF offset)

--- a/src/field3d_io.cxx
+++ b/src/field3d_io.cxx
@@ -32,8 +32,7 @@
 
 template<typename TF>
 Field3d_io<TF>::Field3d_io(Master& masterin, Grid<TF>& gridin) :
-    master(masterin), grid(gridin),
-    transpose(master, grid)
+    master(masterin), grid(gridin)
 {
     sw_transpose = true;    // tmp here for now, becomes argument of save_field3d et al.
 }
@@ -220,225 +219,265 @@ int Field3d_io<TF>::load_field3d(TF* const restrict data, TF* const restrict tmp
 template<typename TF>
 int Field3d_io<TF>::save_xz_slice(TF* restrict data, TF* restrict tmp, const char* filename, int jslice)
 {
-//    auto& gd = grid.get_grid_data();
-//    auto& md = master.get_MPI_data();
-//
-//    // extract the data from the 3d field without the ghost cells
-//    int nerror = 0;
-//
-//    const int jj  = gd.icells;
-//    const int kk  = gd.icells*gd.jcells;
-//    const int kkb = gd.imax;
-//
-//    int count = gd.imax*gd.kmax;
-//
-//    for (int k=0; k<gd.kmax; k++)
-//        #pragma ivdep
-//        for (int i=0; i<gd.imax; i++)
-//        {
-//            // take the modulus of jslice and gd.jmax to have the right offset within proc
-//            const int ijk  = i+gd.igc + ((jslice%gd.jmax)+gd.jgc)*jj + (k+gd.kgc)*kk;
-//            const int ijkb = i + k*kkb;
-//            tmp[ijkb] = data[ijk];
-//        }
-//
-//    if (md.mpicoordy == jslice/gd.jmax)
-//    {
-//        MPI_File fh;
-//        if (MPI_File_open(md.commx, filename, MPI_MODE_CREATE | MPI_MODE_WRONLY | MPI_MODE_EXCL, MPI_INFO_NULL, &fh))
-//            ++nerror;
-//
-//        // select noncontiguous part of 3d array to store the selected data
-//        MPI_Offset fileoff = 0; // the offset within the file (header size)
-//        char name[] = "native";
-//
-//        if (!nerror)
-//            if (MPI_File_set_view(fh, fileoff, mpi_fp_type<TF>(), subxzslice, name, MPI_INFO_NULL))
-//                ++nerror;
-//
-//        // only write at the procs that contain the slice
-//        if (!nerror)
-//            if (MPI_File_write_all(fh, tmp, count, mpi_fp_type<TF>(), MPI_STATUS_IGNORE))
-//                ++nerror;
-//
-//        if (!nerror)
-//            MPI_File_sync(fh);
-//
-//        if (!nerror)
-//            if (MPI_File_close(&fh))
-//                ++nerror;
-//    }
-//
-//    // Gather errors from other processes
-//    master.sum(&nerror,1);
-//
-//    MPI_Barrier(md.commxy);
-//
-//    return nerror;
+    auto& gd = grid.get_grid_data();
+    auto& md = master.get_MPI_data();
+
+    int nerror = 0;
+
+    const int jj  = gd.icells;
+    const int kk  = gd.icells*gd.jcells;
+    const int kkb = gd.imax;
+
+    int count = gd.imax*gd.kmax;
+
+
+    for (int k=0; k<gd.kmax; k++)
+        #pragma ivdep
+        for (int i=0; i<gd.imax; i++)
+        {
+            // take the modulus of jslice and gd.jmax to have the right offset within proc
+            const int ijk  = i+gd.igc + ((jslice%gd.jmax)+gd.jgc)*jj + (k+gd.kgc)*kk;
+            const int ijkb = i + k*kkb;
+            tmp[ijkb] = data[ijk];
+        }
+
+    if (md.mpicoordy == jslice/gd.jmax)
+    {
+        // Create MPI datatype for XZ-slice
+        MPI_Datatype subxzslice;
+        int totxzsize [2] = {gd.kmax, gd.itot};
+        int subxzsize [2] = {gd.kmax, gd.imax};
+        int subxzstart[2] = {0, md.mpicoordx*gd.imax};
+        MPI_Type_create_subarray(2, totxzsize, subxzsize, subxzstart, MPI_ORDER_C, mpi_fp_type<TF>(), &subxzslice);
+        MPI_Type_commit(&subxzslice);
+
+        MPI_File fh;
+        if (MPI_File_open(md.commx, filename, MPI_MODE_CREATE | MPI_MODE_WRONLY | MPI_MODE_EXCL, MPI_INFO_NULL, &fh))
+            ++nerror;
+
+        // select noncontiguous part of 3d array to store the selected data
+        MPI_Offset fileoff = 0; // the offset within the file (header size)
+        char name[] = "native";
+
+        if (!nerror)
+            if (MPI_File_set_view(fh, fileoff, mpi_fp_type<TF>(), subxzslice, name, MPI_INFO_NULL))
+                ++nerror;
+
+        // only write at the procs that contain the slice
+        if (!nerror)
+            if (MPI_File_write_all(fh, tmp, count, mpi_fp_type<TF>(), MPI_STATUS_IGNORE))
+                ++nerror;
+
+        if (!nerror)
+            MPI_File_sync(fh);
+
+        if (!nerror)
+            if (MPI_File_close(&fh))
+                ++nerror;
+
+        MPI_Type_free(&subxzslice);
+    }
+
+    // Gather errors from other processes
+    master.sum(&nerror,1);
+
+    MPI_Barrier(md.commxy);
+
+    return nerror;
 }
 
 template<typename TF>
 int Field3d_io<TF>::save_yz_slice(TF* restrict data, TF* restrict tmp, const char* filename, int islice)
 {
-//    auto& gd = grid.get_grid_data();
-//    auto& md = master.get_MPI_data();
-//
-//    // extract the data from the 3d field without the ghost cells
-//    int nerror = 0;
-//
-//    const int jj = gd.icells;
-//    const int kk = gd.ijcells;
-//
-//    const int kkb = gd.jmax;
-//
-//    int count = gd.jmax*gd.kmax;
-//
-//    // Strip off the ghost cells
-//    for (int k=0; k<gd.kmax; k++)
-//        #pragma ivdep
-//        for (int j=0; j<gd.jmax; j++)
-//        {
-//            // take the modulus of jslice and jmax to have the right offset within proc
-//            const int ijk  = (islice%gd.imax)+gd.igc + (j+gd.jgc)*jj + (k+gd.kgc)*kk;
-//            const int ijkb = j + k*kkb;
-//            tmp[ijkb] = data[ijk];
-//        }
-//
-//    if (md.mpicoordx == islice/gd.imax)
-//    {
-//        MPI_File fh;
-//        if (MPI_File_open(md.commy, filename, MPI_MODE_CREATE | MPI_MODE_WRONLY | MPI_MODE_EXCL, MPI_INFO_NULL, &fh))
-//            ++nerror;
-//
-//        // select noncontiguous part of 3d array to store the selected data
-//        MPI_Offset fileoff = 0; // the offset within the file (header size)
-//        char name[] = "native";
-//
-//        if (!nerror)
-//            if (MPI_File_set_view(fh, fileoff, mpi_fp_type<TF>(), subyzslice, name, MPI_INFO_NULL))
-//                ++nerror;
-//
-//        // only write at the procs that contain the slice
-//        if (!nerror)
-//            if (MPI_File_write_all(fh, tmp, count, mpi_fp_type<TF>(), MPI_STATUS_IGNORE))
-//                ++nerror;
-//
-//        if (!nerror)
-//            MPI_File_sync(fh);
-//
-//        if (!nerror)
-//            if (MPI_File_close(&fh))
-//                ++nerror;
-//    }
-//
-//    // Gather errors from other processes
-//    master.sum(&nerror,1);
-//
-//    MPI_Barrier(md.commxy);
-//
-//    return nerror;
+    auto& gd = grid.get_grid_data();
+    auto& md = master.get_MPI_data();
+
+    int nerror = 0;
+
+    const int jj = gd.icells;
+    const int kk = gd.ijcells;
+
+    const int kkb = gd.jmax;
+
+    int count = gd.jmax*gd.kmax;
+
+
+    // Strip off the ghost cells
+    for (int k=0; k<gd.kmax; k++)
+        #pragma ivdep
+        for (int j=0; j<gd.jmax; j++)
+        {
+            // take the modulus of jslice and jmax to have the right offset within proc
+            const int ijk  = (islice%gd.imax)+gd.igc + (j+gd.jgc)*jj + (k+gd.kgc)*kk;
+            const int ijkb = j + k*kkb;
+            tmp[ijkb] = data[ijk];
+        }
+
+    if (md.mpicoordx == islice/gd.imax)
+    {
+        // Create MPI datatype for YZ-slice
+        MPI_Datatype subyzslice;
+        int totyzsize [2] = {gd.kmax, gd.jtot};
+        int subyzsize [2] = {gd.kmax, gd.jmax};
+        int subyzstart[2] = {0, md.mpicoordy*gd.jmax};
+        MPI_Type_create_subarray(2, totyzsize, subyzsize, subyzstart, MPI_ORDER_C, mpi_fp_type<TF>(), &subyzslice);
+        MPI_Type_commit(&subyzslice);
+
+        MPI_File fh;
+        if (MPI_File_open(md.commy, filename, MPI_MODE_CREATE | MPI_MODE_WRONLY | MPI_MODE_EXCL, MPI_INFO_NULL, &fh))
+            ++nerror;
+
+        // select noncontiguous part of 3d array to store the selected data
+        MPI_Offset fileoff = 0; // the offset within the file (header size)
+        char name[] = "native";
+
+        if (!nerror)
+            if (MPI_File_set_view(fh, fileoff, mpi_fp_type<TF>(), subyzslice, name, MPI_INFO_NULL))
+                ++nerror;
+
+        // only write at the procs that contain the slice
+        if (!nerror)
+            if (MPI_File_write_all(fh, tmp, count, mpi_fp_type<TF>(), MPI_STATUS_IGNORE))
+                ++nerror;
+
+        if (!nerror)
+            MPI_File_sync(fh);
+
+        if (!nerror)
+            if (MPI_File_close(&fh))
+                ++nerror;
+
+        MPI_Type_free(&subyzslice);
+    }
+
+    // Gather errors from other processes
+    master.sum(&nerror,1);
+
+    MPI_Barrier(md.commxy);
+
+    return nerror;
 }
 
 template<typename TF>
 int Field3d_io<TF>::save_xy_slice(TF* restrict data, TF* restrict tmp, const char* filename, int kslice)
 {
-//    auto& gd = grid.get_grid_data();
-//    auto& md = master.get_MPI_data();
-//
-//    // extract the data from the 3d field without the ghost cells
-//    const int jj  = gd.icells;
-//    const int kk  = gd.icells*gd.jcells;
-//    const int jjb = gd.imax;
-//
-//    // Subtract the ghost cells in case of a pure 2d plane that does not have ghost cells.
-//    if (kslice == -1)
-//        kslice = -gd.kgc;
-//
-//    int count = gd.imax*gd.jmax;
-//
-//    for (int j=0; j<gd.jmax; j++)
-//        #pragma ivdep
-//        for (int i=0; i<gd.imax; i++)
-//        {
-//            // take the modulus of jslice and jmax to have the right offset within proc
-//            const int ijk  = i+gd.igc + (j+gd.jgc)*jj + (kslice+gd.kgc)*kk;
-//            const int ijkb = i + j*jjb;
-//            tmp[ijkb] = data[ijk];
-//        }
-//
-//    MPI_File fh;
-//    if (MPI_File_open(md.commxy, filename, MPI_MODE_CREATE | MPI_MODE_WRONLY | MPI_MODE_EXCL, MPI_INFO_NULL, &fh))
-//        return 1;
-//
-//    // select noncontiguous part of 3d array to store the selected data
-//    MPI_Offset fileoff = 0; // the offset within the file (header size)
-//    char name[] = "native";
-//
-//    if (MPI_File_set_view(fh, fileoff, mpi_fp_type<TF>(), subxyslice, name, MPI_INFO_NULL))
-//        return 1;
-//
-//    // only write at the procs that contain the slice
-//    if (MPI_File_write_all(fh, tmp, count, mpi_fp_type<TF>(), MPI_STATUS_IGNORE))
-//        return 1;
-//
-//    MPI_File_sync(fh);
-//
-//    if (MPI_File_close(&fh))
-//        return 1;
-//
-//    MPI_Barrier(md.commxy);
-//
-//    return 0;
+    auto& gd = grid.get_grid_data();
+    auto& md = master.get_MPI_data();
+
+    // extract the data from the 3d field without the ghost cells
+    const int jj  = gd.icells;
+    const int kk  = gd.icells*gd.jcells;
+    const int jjb = gd.imax;
+
+    // Subtract the ghost cells in case of a pure 2d plane that does not have ghost cells.
+    if (kslice == -1)
+        kslice = -gd.kgc;
+
+    int count = gd.imax*gd.jmax;
+
+    for (int j=0; j<gd.jmax; j++)
+        #pragma ivdep
+        for (int i=0; i<gd.imax; i++)
+        {
+            // take the modulus of jslice and jmax to have the right offset within proc
+            const int ijk  = i+gd.igc + (j+gd.jgc)*jj + (kslice+gd.kgc)*kk;
+            const int ijkb = i + j*jjb;
+            tmp[ijkb] = data[ijk];
+        }
+
+    // Define MPI datatype for XY-slice
+    MPI_Datatype subxyslice;
+    int totxysize [2] = {gd.jtot, gd.itot};
+    int subxysize [2] = {gd.jmax, gd.imax};
+    int subxystart[2] = {md.mpicoordy*gd.jmax, md.mpicoordx*gd.imax};
+    MPI_Type_create_subarray(2, totxysize, subxysize, subxystart, MPI_ORDER_C, mpi_fp_type<TF>(), &subxyslice);
+    MPI_Type_commit(&subxyslice);
+
+    MPI_File fh;
+    if (MPI_File_open(md.commxy, filename, MPI_MODE_CREATE | MPI_MODE_WRONLY | MPI_MODE_EXCL, MPI_INFO_NULL, &fh))
+        return 1;
+
+    // select noncontiguous part of 3d array to store the selected data
+    MPI_Offset fileoff = 0; // the offset within the file (header size)
+    char name[] = "native";
+
+    if (MPI_File_set_view(fh, fileoff, mpi_fp_type<TF>(), subxyslice, name, MPI_INFO_NULL))
+        return 1;
+
+    // only write at the procs that contain the slice
+    if (MPI_File_write_all(fh, tmp, count, mpi_fp_type<TF>(), MPI_STATUS_IGNORE))
+        return 1;
+
+    MPI_File_sync(fh);
+
+    if (MPI_File_close(&fh))
+        return 1;
+
+    MPI_Type_free(&subxyslice);
+
+    MPI_Barrier(md.commxy);
+
+    return 0;
 }
 
 template<typename TF>
 int Field3d_io<TF>::load_xy_slice(TF* restrict data, TF* restrict tmp, const char* filename, int kslice)
 {
-//    auto& gd = grid.get_grid_data();
-//    auto& md = master.get_MPI_data();
-//
-//    // extract the data from the 3d field without the ghost cells
-//    const int jj = gd.icells;
-//    const int kk = gd.icells*gd.jcells;
-//    const int jjb = gd.imax;
-//
-//    // Subtract the ghost cells in case of a pure 2d plane that does not have ghost cells.
-//    if (kslice == -1)
-//        kslice = -gd.kgc;
-//
-//    int count = gd.imax*gd.jmax;
-//
-//    MPI_File fh;
-//    if (MPI_File_open(md.commxy, filename, MPI_MODE_RDONLY, MPI_INFO_NULL, &fh))
-//        return 1;
-//
-//    // select noncontiguous part of 3d array to store the selected data
-//    MPI_Offset fileoff = 0; // the offset within the file (header size)
-//    char name[] = "native";
-//
-//    if (MPI_File_set_view(fh, fileoff, mpi_fp_type<TF>(), subxyslice, name, MPI_INFO_NULL))
-//        return 1;
-//
-//    // only write at the procs that contain the slice
-//    if (MPI_File_read_all(fh, tmp, count, mpi_fp_type<TF>(), MPI_STATUS_IGNORE))
-//        return 1;
-//
-//    if (MPI_File_close(&fh))
-//        return 1;
-//
-//    MPI_Barrier(md.commxy);
-//
-//    for (int j=0; j<gd.jmax; j++)
-//        #pragma ivdep
-//        for (int i=0; i<gd.imax; i++)
-//        {
-//            // take the modulus of jslice and jmax to have the right offset within proc
-//            const int ijk  = i+gd.igc + (j+gd.jgc)*jj + (kslice+gd.kgc)*kk;
-//            const int ijkb = i + j*jjb;
-//            data[ijk] = tmp[ijkb];
-//        }
-//
-//    return 0;
+    auto& gd = grid.get_grid_data();
+    auto& md = master.get_MPI_data();
+
+    // extract the data from the 3d field without the ghost cells
+    const int jj = gd.icells;
+    const int kk = gd.icells*gd.jcells;
+    const int jjb = gd.imax;
+
+    // Subtract the ghost cells in case of a pure 2d plane that does not have ghost cells.
+    if (kslice == -1)
+        kslice = -gd.kgc;
+
+    int count = gd.imax*gd.jmax;
+
+    // Create MPI datatype for XY-slice read
+    MPI_Datatype subxyslice;
+    int totxysize [2] = {gd.jtot, gd.itot};
+    int subxysize [2] = {gd.jmax, gd.imax};
+    int subxystart[2] = {md.mpicoordy*gd.jmax, md.mpicoordx*gd.imax};
+    MPI_Type_create_subarray(2, totxysize, subxysize, subxystart, MPI_ORDER_C, mpi_fp_type<TF>(), &subxyslice);
+    MPI_Type_commit(&subxyslice);
+
+    MPI_File fh;
+    if (MPI_File_open(md.commxy, filename, MPI_MODE_RDONLY, MPI_INFO_NULL, &fh))
+        return 1;
+
+    // select noncontiguous part of 3d array to store the selected data
+    MPI_Offset fileoff = 0; // the offset within the file (header size)
+    char name[] = "native";
+
+    if (MPI_File_set_view(fh, fileoff, mpi_fp_type<TF>(), subxyslice, name, MPI_INFO_NULL))
+        return 1;
+
+    // only write at the procs that contain the slice
+    if (MPI_File_read_all(fh, tmp, count, mpi_fp_type<TF>(), MPI_STATUS_IGNORE))
+        return 1;
+
+    if (MPI_File_close(&fh))
+        return 1;
+
+    MPI_Type_free(&subxyslice);
+
+    MPI_Barrier(md.commxy);
+
+    for (int j=0; j<gd.jmax; j++)
+        #pragma ivdep
+        for (int i=0; i<gd.imax; i++)
+        {
+            // take the modulus of jslice and jmax to have the right offset within proc
+            const int ijk  = i+gd.igc + (j+gd.jgc)*jj + (kslice+gd.kgc)*kk;
+            const int ijkb = i + j*jjb;
+            data[ijk] = tmp[ijkb];
+        }
+
+    return 0;
 }
 
 #else

--- a/src/field3d_io.cxx
+++ b/src/field3d_io.cxx
@@ -380,18 +380,14 @@ int Field3d_io<TF>::save_xy_slice(TF* restrict data, TF* restrict tmp, const cha
     const int kk  = gd.icells*gd.jcells;
     const int jjb = gd.imax;
 
-    // Subtract the ghost cells in case of a pure 2d plane that does not have ghost cells.
-    if (kslice == -1)
-        kslice = -gd.kgc;
-
-    int count = gd.imax*gd.jmax;
+    const int count = gd.imax*gd.jmax;
 
     for (int j=0; j<gd.jmax; j++)
         #pragma ivdep
         for (int i=0; i<gd.imax; i++)
         {
-            // take the modulus of jslice and jmax to have the right offset within proc
-            const int ijk  = i+gd.igc + (j+gd.jgc)*jj + (kslice+gd.kgc)*kk;
+            // Take the modulus of jslice and jmax to have the right offset within proc
+            const int ijk  = i+gd.igc + (j+gd.jgc)*jj + kslice*kk;
             const int ijkb = i + j*jjb;
             tmp[ijkb] = data[ijk];
         }
@@ -585,7 +581,7 @@ int Field3d_io<TF>::save_xz_slice(TF* restrict data, TF* restrict tmp, const cha
     const int count = gd.imax*gd.kmax;
 
     for (int k=0; k<gd.kmax; k++)
-#pragma ivdep
+        #pragma ivdep
         for (int i=0; i<gd.imax; i++)
         {
             // take the modulus of jslice and gd.jmax to have the right offset within proc
@@ -652,16 +648,12 @@ int Field3d_io<TF>::save_xy_slice(TF* restrict data, TF* restrict tmp, const cha
 
     const int count = gd.imax*gd.jmax;
 
-    // Subtract the ghost cells in case of a pure 2d plane that does not have ghost cells.
-    if (kslice == -1)
-        kslice = -gd.kgc;
-
     for (int j=0; j<gd.jmax; j++)
-#pragma ivdep
+        #pragma ivdep
         for (int i=0; i<gd.imax; i++)
         {
-            // take the modulus of jslice and jmax to have the right offset within proc
-            const int ijk  = i+gd.igc + (j+gd.jgc)*jj + (kslice+gd.kgc)*kk;
+            // Take the modulus of jslice and jmax to have the right offset within proc
+            const int ijk  = i+gd.igc + (j+gd.jgc)*jj + kslice*kk;
             const int ijkb = i + j*jjb;
             tmp[ijkb] = data[ijk];
         }
@@ -702,7 +694,7 @@ int Field3d_io<TF>::load_xy_slice(TF* restrict data, TF* restrict tmp, const cha
     const int jjb = gd.imax;
 
     for (int j=0; j<gd.jmax; j++)
-#pragma ivdep
+        #pragma ivdep
         for (int i=0; i<gd.imax; i++)
         {
             const int ijk  = i+gd.igc + (j+gd.jgc)*jj + (kslice+gd.kgc)*kk;

--- a/src/field3d_io.cxx
+++ b/src/field3d_io.cxx
@@ -440,7 +440,7 @@ int Field3d_io<TF>::save_xy_slice(
 template<typename TF>
 int Field3d_io<TF>::load_xy_slice(
         TF* const restrict data, TF* const restrict tmp,
-        const char* filename, const int kslice)
+        const char* filename, int kslice)
 {
     auto& gd = grid.get_grid_data();
     auto& md = master.get_MPI_data();
@@ -696,7 +696,7 @@ int Field3d_io<TF>::save_xy_slice(
 template<typename TF>
 int Field3d_io<TF>::load_xy_slice(
         TF* const restrict data, TF* const restrict tmp,
-        const char* filename, const int kslice)
+        const char* filename, int kslice)
 {
     auto& gd = grid.get_grid_data();
 

--- a/src/fields.cxx
+++ b/src/fields.cxx
@@ -895,6 +895,7 @@ void Fields<TF>::create_column(Column<TF>& column)
 template<typename TF>
 void Fields<TF>::save(int n)
 {
+    auto& gd = grid.get_grid_data();
     const TF no_offset = 0.;
 
     auto tmp1 = get_tmp();
@@ -908,8 +909,11 @@ void Fields<TF>::save(int n)
         master.print_message("Saving \"%s\" ... ", filename);
 
         // The offset is kept at zero, because otherwise bitwise identical restarts are not possible.
-        if (field3d_io.save_field3d(f.second->fld.data(), tmp1->fld.data(), tmp2->fld.data(),
-                    filename, no_offset))
+        if (field3d_io.save_field3d(
+                    f.second->fld.data(),
+                    tmp1->fld.data(), tmp2->fld.data(),
+                    filename, no_offset,
+                    gd.kstart, gd.kend))
         {
             master.print_message("FAILED\n");
             ++nerror;
@@ -932,6 +936,7 @@ void Fields<TF>::save(int n)
 template<typename TF>
 void Fields<TF>::load(int n)
 {
+    auto& gd = grid.get_grid_data();
     const TF no_offset = 0.;
 
     auto tmp1 = get_tmp();
@@ -946,8 +951,11 @@ void Fields<TF>::load(int n)
         std::sprintf(filename, "%s.%07d", f.second->name.c_str(), n);
         master.print_message("Loading \"%s\" ... ", filename);
 
-        if (field3d_io.load_field3d(f.second->fld.data(), tmp1->fld.data(), tmp2->fld.data(),
-                    filename, no_offset))
+        if (field3d_io.load_field3d(
+                    f.second->fld.data(),
+                    tmp1->fld.data(), tmp2->fld.data(),
+                    filename, no_offset,
+                    gd.kstart, gd.kend))
         {
             master.print_message("FAILED\n");
             ++nerror;

--- a/src/fields.cxx
+++ b/src/fields.cxx
@@ -332,9 +332,6 @@ void Fields<TF>::init(Input& input, Dump<TF>& dump, Cross<TF>& cross, const Sim_
     umodel.resize(gd.kcells);
     vmodel.resize(gd.kcells);
 
-    // Init the toolbox classes.
-    field3d_io.init();
-
     // Set up output classes
     create_dump(dump);
     create_cross(cross);


### PR DESCRIPTION
Moved the definition of the MPI types to the individual `field3d_io` functions, and added option to specify the vertical grid levels in `save_field3d` and `load_field3d`. Advantages: 
- Manual `init()` of `field3d_io` no longer necessary
- More flexibility (which I needed for writing e.g. the soil restart files).